### PR TITLE
Support writing HPO annotations into HPOA format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Cargo.lock
 #.idea/
 
 .vscode/
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ authors = [
 [dependencies]
 clap = { version = "4.5", features = ["derive"], optional = true }
 flate2 = { version = "1.0", optional = true }
-ontolius = { version = "0.7", default-features = false }
+ontolius = { version = "0.7.1", default-features = false }
 regex = "1.11.1"
 serde = { version = "1.0.197", features = ["derive"], optional = true }
 serde_json = { version = "1.0.140", optional = true }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,7 @@
+//! The data formats of ontology annotations.
+
+/// Human Phenotype Ontology annotation format.
+pub struct Hpoa;
+
+/// Gene Ontology annotation format.
+pub struct Gaf;

--- a/src/go.rs
+++ b/src/go.rs
@@ -1,14 +1,13 @@
 //! Parse Gene Ontology annotations.
-//!
-//! Use [`GoGafAnnotationLoader`] to parse GAF file into [`GoAnnotations`].
+
+use crate::format::Gaf;
+use crate::io::{AnnotationLoadError, AnnotationLoader, ValidationIssue};
 use ontolius::TermId;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::io::BufRead;
 use std::str::FromStr;
-
-use crate::io::{AnnotationLoadError, AnnotationLoader, ValidationIssue};
 
 /// The number of columns in GO GAF file.
 const GOA_EXPECTED_FIELDS: usize = 17;
@@ -223,10 +222,8 @@ pub struct GoAnnotations {
     pub negated_annotation_count: usize,
 }
 
-pub struct GoGafAnnotationLoader;
-
-impl AnnotationLoader<GoAnnotations> for GoGafAnnotationLoader {
-    fn load_from_buf_read<R>(&self, read: R) -> Result<GoAnnotations, AnnotationLoadError>
+impl AnnotationLoader<Gaf> for GoAnnotations {
+    fn load_from_buf_read<R>(read: R) -> Result<GoAnnotations, AnnotationLoadError>
     where
         R: BufRead,
     {
@@ -377,7 +374,6 @@ pub mod stats {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     #[test]

--- a/src/hpo.rs
+++ b/src/hpo.rs
@@ -827,7 +827,7 @@ pub mod io {
     };
     use ontolius::{Prefix, TermIdParseError};
     use regex::Regex;
-    use std::collections::BTreeMap;
+    use std::collections::{HashMap, HashSet};
     use std::fmt::{Debug, Display};
     use std::io::{BufRead, Write};
     use std::sync::LazyLock;
@@ -983,7 +983,7 @@ pub mod io {
             W: Write,
         {
             // Comments
-            // #description: "HPO annotations for rare diseases [8362: OMIM; 47: DECIPHER; 4283 ORPHANET]"
+            // #description: "HPO annotations for rare diseases [8362: OMIM; 47: DECIPHER; 4283 ORPHA]"
             let disease_counts = count_diseases(&self.lines);
             write!(
                 &mut write,
@@ -1031,10 +1031,11 @@ pub mod io {
     }
 
     fn count_diseases(lines: &[HpoAnnotation]) -> Vec<(Prefix<'_>, u32)> {
-        let mut counts = BTreeMap::new();
+        let disease_ids: HashSet<_> = lines.iter().map(|ann| &ann.disease_id).collect();
 
-        for ann in lines {
-            *counts.entry(ann.disease_id.prefix()).or_default() += 1;
+        let mut counts = HashMap::new();
+        for disease_id in disease_ids {
+            *counts.entry(disease_id.prefix()).or_default() += 1;
         }
 
         counts.into_iter().collect()
@@ -1316,7 +1317,7 @@ pub mod io {
             assert_eq!(
                 &lines,
                 &[
-                    "#description: \"HPO annotations for rare diseases [4: OMIM; 4: ORPHA]\"",
+                    "#description: \"HPO annotations for rare diseases [1: OMIM; 1: ORPHA]\"",
                     "#version: 2025-05-06",
                     "#tracker: https://github.com/obophenotype/human-phenotype-ontology/issues",
                     "#hpo-version: https://purl.obolibrary.org/obo/hp/releases/2025-05-06/hp.json",

--- a/src/hpo.rs
+++ b/src/hpo.rs
@@ -3,6 +3,8 @@
 use ontolius::TermId;
 use regex::Regex;
 use std::fmt::{Display, Formatter};
+use std::hash::Hash;
+use std::marker::PhantomData;
 use std::{str::FromStr, sync::LazyLock};
 
 /// Evidence codes used in HPO.
@@ -138,6 +140,11 @@ impl AnnotationReference {
 /// The [`FrequencyData::Ratio`] is preferred over the other forms.
 #[derive(Debug, Clone, PartialEq)]
 pub enum FrequencyData {
+    /*
+    Notes
+    `FrequencyData` cannot implement `Eq` because `FrequencyData::Percentage` can be created with a `f64:NAN`.
+    Nor can `Hash` be implemented due to `f64`.
+     */
     /// Frequency data as [`TermId`], a member of HPO's
     /// [Frequency \[HP:0040279\]](https://hpo.jax.org/browse/term/HP:0040279) submodule.
     TermId(TermId),
@@ -480,12 +487,34 @@ mod test_frequency {
     }
 
     #[test]
+    fn test_cannot_create_from_nan_or_infinity() {
+        assert_eq!(
+            Frequency::from_percentage(f64::NAN).unwrap_err(),
+            FrequencyParseError::PercentageOutOfBounds
+        );
+        assert_eq!(
+            Frequency::from_percentage(f64::INFINITY).unwrap_err(),
+            FrequencyParseError::PercentageOutOfBounds
+        );
+        assert_eq!(
+            Frequency::from_percentage(f64::NEG_INFINITY).unwrap_err(),
+            FrequencyParseError::PercentageOutOfBounds
+        );
+    }
+
+    #[test]
+    fn test_can_create_percentage_from_min_positive() {
+        assert!(Frequency::from_percentage(f64::MIN_POSITIVE).is_ok());
+    }
+
+    #[test]
     fn test_we_pay_nothing_for_the_frequency_wrapper() {
         assert_eq!(size_of::<Frequency>(), size_of::<FrequencyData>());
     }
 }
 
-/// Annotation of a disease with HPO term, including the annotation modifiers.
+/// Annotation of a disease with HPO term, including the annotation modifiers, onset, sex,
+/// clinical modifiers and the curators.
 #[derive(Debug, Clone, PartialEq)]
 pub struct HpoAnnotation {
     pub disease_id: TermId,
@@ -499,6 +528,279 @@ pub struct HpoAnnotation {
     pub modifiers: Vec<TermId>,
     pub aspect: Aspect,
     pub curators: Vec<String>,
+}
+
+impl HpoAnnotation {
+    /// Create a builder for building the [`HpoAnnotation`].
+    pub fn builder() -> HpoAnnotationBuilder<Unset, Unset, Unset> {
+        HpoAnnotationBuilder {
+            disease: None,
+            is_negated: false,
+            phenotype_term_id: None,
+            annotation_references: vec![],
+            onset: None,
+            frequency: None,
+            sex: None,
+            modifiers: vec![],
+            aspect: None,
+            curators: vec![],
+            state: PhantomData,
+        }
+    }
+}
+
+/// A marker struct to indicate that a required field of [`HpoAnnotation] was set.
+pub struct Set;
+
+/// A marker struct to indicate that a required field of [`HpoAnnotation] was not set.
+pub struct Unset;
+
+/// A builder for [`HpoAnnotation`].
+///
+/// Three required fields must be set on the builder ...
+/// * [`HpoAnnotationBuilder::disease`]
+/// * [`HpoAnnotationBuilder::phenotype`]
+/// * [`HpoAnnotationBuilder::aspect`]
+///
+/// ... before the annotation can be built with [`HpoAnnotationBuilder::build`].
+pub struct HpoAnnotationBuilder<D, P, A> {
+    // The builder has a generic parameter for each required field/condition.
+    disease: Option<(TermId, String)>,
+    is_negated: bool,
+    phenotype_term_id: Option<TermId>,
+    annotation_references: Vec<AnnotationReference>,
+    onset: Option<TermId>,
+    frequency: Option<Frequency>,
+    sex: Option<Sex>,
+    modifiers: Vec<TermId>,
+    aspect: Option<Aspect>,
+    curators: Vec<String>,
+    state: PhantomData<(D, P, A)>,
+}
+
+impl<P, A> HpoAnnotationBuilder<Unset, P, A> {
+    /// Set the disease identifier (e.g. `OMIM:154700`) and its name (e.g. `Marfan syndrome`).
+    pub fn disease(
+        self,
+        disease_id: impl Into<TermId>,
+        name: impl ToString,
+    ) -> HpoAnnotationBuilder<Set, P, A> {
+        HpoAnnotationBuilder {
+            disease: Some((disease_id.into(), name.to_string())),
+            is_negated: self.is_negated,
+            phenotype_term_id: self.phenotype_term_id,
+            annotation_references: self.annotation_references,
+            onset: self.onset,
+            frequency: self.frequency,
+            sex: self.sex,
+            modifiers: self.modifiers,
+            aspect: self.aspect,
+            curators: self.curators,
+            state: PhantomData,
+        }
+    }
+}
+
+impl<D, A> HpoAnnotationBuilder<D, Unset, A> {
+    /// Set the phenotype annotation term id.
+    pub fn phenotype(self, phenotype: impl Into<TermId>) -> HpoAnnotationBuilder<D, Set, A> {
+        HpoAnnotationBuilder {
+            disease: self.disease,
+            is_negated: self.is_negated,
+            phenotype_term_id: Some(phenotype.into()),
+            annotation_references: self.annotation_references,
+            onset: self.onset,
+            frequency: self.frequency,
+            sex: self.sex,
+            modifiers: self.modifiers,
+            aspect: self.aspect,
+            curators: self.curators,
+            state: PhantomData,
+        }
+    }
+}
+
+impl<D, P> HpoAnnotationBuilder<D, P, Unset> {
+    /// Set the aspect of the HPO annotation.
+    pub fn aspect(self, aspect: Aspect) -> HpoAnnotationBuilder<D, P, Set> {
+        HpoAnnotationBuilder {
+            disease: self.disease,
+            is_negated: self.is_negated,
+            phenotype_term_id: self.phenotype_term_id,
+            annotation_references: self.annotation_references,
+            onset: self.onset,
+            frequency: self.frequency,
+            sex: self.sex,
+            modifiers: self.modifiers,
+            aspect: Some(aspect),
+            curators: self.curators,
+            state: PhantomData,
+        }
+    }
+
+    /// Set aspect to [`Aspect::Phenotype`].
+    pub fn aspect_phenotype(self) -> HpoAnnotationBuilder<D, P, Set> {
+        self.aspect(Aspect::Phenotype)
+    }
+
+    /// Set aspect to [`Aspect::ClinicalCourse`].
+    pub fn aspect_clinical_course(self) -> HpoAnnotationBuilder<D, P, Set> {
+        self.aspect(Aspect::ClinicalCourse)
+    }
+
+    /// Set aspect to [`Aspect::Inheritance`].
+    pub fn aspect_inheritance(self) -> HpoAnnotationBuilder<D, P, Set> {
+        self.aspect(Aspect::Inheritance)
+    }
+}
+
+impl<D, P, A> HpoAnnotationBuilder<D, P, A> {
+    /// Indicate that the phenotype is *NOT* a characteristic of the annotated disease.
+    pub fn negated(mut self) -> Self {
+        self.is_negated = true;
+        self
+    }
+
+    /// Indicate that the phenotype is a characteristic of the annotated disease.
+    ///
+    /// The phenotype is observed by default and this method does not have to be set.
+    pub fn not_negated(mut self) -> Self {
+        self.is_negated = false;
+        self
+    }
+
+    /// Add an annotation reference to the annotation.
+    pub fn push_annotation_reference(mut self, annotation_reference: AnnotationReference) -> Self {
+        self.annotation_references.push(annotation_reference);
+        self
+    }
+
+    /// Add multiple annotation references to the annotation.
+    pub fn extend_annotation_references(
+        mut self,
+        annotation_references: impl IntoIterator<Item = AnnotationReference>,
+    ) -> Self {
+        self.annotation_references.extend(annotation_references);
+        self
+    }
+
+    /// Clear all previously added annotation references.
+    pub fn clear_annotation_references(mut self) -> Self {
+        self.annotation_references.clear();
+        self
+    }
+
+    /// Set the onset of the annotation. The `onset` should be a member of HPO's
+    /// [Onset](https://hpo.jax.org/browse/term/HP:0003674) module.
+    pub fn onset(mut self, onset: impl Into<TermId>) -> Self {
+        self.onset = Some(onset.into());
+        self
+    }
+
+    /// Set the frequency of the annotation.
+    pub fn frequency(mut self, frequency: impl Into<Frequency>) -> Self {
+        self.frequency = Some(frequency.into());
+        self
+    }
+
+    /// Set sex of the annotation.
+    pub fn sex(mut self, sex: Sex) -> Self {
+        self.sex = Some(sex);
+        self
+    }
+
+    /// Set sex to [`Sex::Male`].
+    pub fn sex_male(self) -> Self {
+        self.sex(Sex::Male)
+    }
+
+    /// Set sex to [`Sex::Female`].
+    pub fn sex_female(self) -> Self {
+        self.sex(Sex::Female)
+    }
+
+    /// Set sex to [`Sex::Unknown`].
+    pub fn sex_unknown(self) -> Self {
+        self.sex(Sex::Unknown)
+    }
+
+    /// Add a clinical modifier.
+    pub fn push_modifier(mut self, modifier: impl Into<TermId>) -> Self {
+        self.modifiers.push(modifier.into());
+        self
+    }
+
+    /// Add several clinical modifiers.
+    pub fn extend_modifiers(
+        mut self,
+        modifiers: impl IntoIterator<Item = impl Into<TermId>>,
+    ) -> Self {
+        self.modifiers
+            .extend(modifiers.into_iter().map(|v| v.into()));
+        self
+    }
+
+    /// Remove all previously added clinical modifiers.
+    pub fn clear_modifiers(mut self) -> Self {
+        self.modifiers.clear();
+        self
+    }
+
+    /// Add a curator record.
+    pub fn push_curator(mut self, curator: impl ToString) -> Self {
+        self.curators.push(curator.to_string());
+        self
+    }
+
+    /// Add several curators.
+    pub fn extend_curators(mut self, curators: impl IntoIterator<Item = impl ToString>) -> Self {
+        self.curators
+            .extend(curators.into_iter().map(|v| v.to_string()));
+        self
+    }
+
+    /// Clear previously added curators.
+    pub fn clear_curators(mut self) -> Self {
+        self.curators.clear();
+        self
+    }
+}
+
+impl HpoAnnotationBuilder<Set, Set, Set> {
+    /// Build the annotation.
+    ///
+    /// The build is infallible due to static checking in the builder.
+    pub fn build(mut self) -> HpoAnnotation {
+        let (disease_id, disease_name) = self
+            .disease
+            .expect("build is callable only after both disease ID and name are set to the builder");
+
+        self.annotation_references.sort_by(|l, r| {
+            l.term_id
+                .cmp(&r.term_id)
+                .then(l.evidence_code.cmp(&r.evidence_code))
+        });
+        self.modifiers.sort();
+        self.curators.sort();
+
+        HpoAnnotation {
+            disease_id,
+            disease_name,
+            is_negated: self.is_negated,
+            phenotype_term_id: self
+                .phenotype_term_id
+                .expect("Build is callable only after phenotype ID is set to the builder"),
+            annotation_references: self.annotation_references,
+            onset: self.onset,
+            frequency: self.frequency,
+            sex: self.sex,
+            modifiers: self.modifiers,
+            aspect: self
+                .aspect
+                .expect("Build is callable only after aspect is set to the builder"),
+            curators: self.curators,
+        }
+    }
 }
 
 /// The HPO annotation corpus with entries parsed to the highest level possible

--- a/src/hpo.rs
+++ b/src/hpo.rs
@@ -1,9 +1,9 @@
 //! Types and I/O for working with HPO Annotations.
 
-use std::{str::FromStr, sync::LazyLock};
-
 use ontolius::TermId;
 use regex::Regex;
+use std::fmt::{Display, Formatter};
+use std::{str::FromStr, sync::LazyLock};
 
 /// Evidence codes used in HPO.
 ///
@@ -94,7 +94,7 @@ impl TryFrom<char> for Aspect {
     }
 }
 
-/// Aspect can be parsed from a `&str` (case insensitive).
+/// Aspect can be parsed from a `&str` (case-insensitive).
 ///
 /// See [`Aspect::try_from<char>`] for more details.
 ///
@@ -136,7 +136,7 @@ pub enum Frequency {
     TermId(TermId),
     /// A count of patients affected within a cohort.
     ///
-    /// For instance, `7/13` would indicate that `7` of the `13` patients with the specified disease
+    /// For instance, `7/13` would indicate that `7` (n) of the `13` (m) patients with the specified disease
     /// were found to have the phenotypic abnormality referred to by the HPO term in question
     /// in the study referred to by the DB reference.
     ///
@@ -144,10 +144,10 @@ pub enum Frequency {
     /// The cohort size is `2` in the former while `4` individuals were investigated in the latter.
     Ratio {
         /// Count of individuals with the annotation.
-        numerator: u32,
+        n: u32,
         /// The total number of the individuals investigated
         /// for the presence of the annotation.
-        denominator: u32,
+        m: u32,
     },
     /// A percentage value such as 17%, again referring to the percentage of patients
     /// found to have the phenotypic abnormality referred to by the HPO term in question
@@ -157,7 +157,8 @@ pub enum Frequency {
     /// if the exact data is available.
     ///
     /// Should be a value in range of `[0..100]`. E.g. `7.` to represent 7%.
-    Frequency(f64),
+    /// The range is, however, *NOT* enforced in any fashion!
+    Percentage(f64),
 }
 
 /// The possible reasons for failing to parse a frequency from a `&str`.
@@ -165,6 +166,8 @@ pub enum Frequency {
 pub enum FrequencyParseError {
     #[error("Empty value")]
     EmptyVal,
+    #[error("`m` is greater than `n`")]
+    NGreaterThanM,
     #[error("Frequency not in range [0, 100]")]
     FrequencyOutOfBounds,
     #[error("Unparsable value")]
@@ -172,20 +175,21 @@ pub enum FrequencyParseError {
 }
 
 static RATIO_PT: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?<numerator>\d+)/(?<denominator>\d+)")
+    Regex::new(r"^(?<numerator>\d+)/(?<denominator>\d+)$")
         .expect("The ratio pattern should be well formatted")
 });
 
 static FREQUENCY_PT: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?<frequency>-?\d+(\.\d*)?)%")
+    Regex::new(r"^(?<frequency>-?\d+(\.\d*)?)%$")
         .expect("The frequency pattern should be well formatted")
 });
 
 /// Parse a frequency string.
 ///
 /// The parsing fails if the payload does not correspond to one of the supported input formats:
-/// * ratio - e.g. `7/13` to represent 7 out of 13.
-/// * percentage - e.g. 53.85%. Percent sign `%` is obligatory.
+/// * ratio - `n`/`m` (e.g. `7/13`) to represent presence of a feature in `n` individuals
+///   out of `m` tested for feature's presence.
+/// * percentage - e.g. 53.85%. Percent sign `%` is obligatory. The value must be between $[0, 100.0]$.
 /// * term ID - e.g. `HP:0040284` for [Very rare (HP:0040284)](https://hpo.jax.org/browse/term/HP:0040284).
 ///
 /// # Note
@@ -207,7 +211,17 @@ static FREQUENCY_PT: LazyLock<Regex> = LazyLock::new(|| {
 /// assert!(frequency.is_ok());
 ///
 /// let frequency = frequency.unwrap();
-/// assert!(matches!(frequency, Frequency::Ratio{numerator: 7, denominator: 13}));
+///
+/// assert_eq!(frequency, Frequency::Ratio {n: 7, m: 13});
+/// ```
+///
+/// Fails if $n>m$:
+/// ```
+/// use oboannotation::hpo::{Frequency, FrequencyParseError};
+///
+/// let frequency: FrequencyParseError = "13/7".parse::<Frequency>().unwrap_err();
+///
+/// assert_eq!(frequency, FrequencyParseError::NGreaterThanM);
 /// ```
 ///
 /// ## Percentage
@@ -221,7 +235,7 @@ static FREQUENCY_PT: LazyLock<Regex> = LazyLock::new(|| {
 /// assert!(frequency.is_ok());
 ///
 /// let frequency = frequency.unwrap();
-/// assert!(matches!(frequency, Frequency::Frequency(53.85)));
+/// assert!(matches!(frequency, Frequency::Percentage(53.85)));
 /// ```
 ///
 /// ## Term id
@@ -247,29 +261,54 @@ impl FromStr for Frequency {
         if s.is_empty() {
             Err(FrequencyParseError::EmptyVal)
         } else if let Some(cap) = RATIO_PT.captures(s) {
-            Ok(Frequency::Ratio {
-                numerator: cap["numerator"]
-                    .parse()
-                    .expect("Regexp should ensure that numerator is parsable into a `u32` value"),
-                denominator: cap["denominator"]
-                    .parse()
-                    .expect("Regexp should ensure that denominator is parsable into a `u32` value"),
-            })
+            let n = cap["numerator"]
+                .parse()
+                .expect("Regexp should ensure that numerator is parsable into a `u32` value");
+            let m = cap["denominator"]
+                .parse()
+                .expect("Regexp should ensure that denominator is parsable into a `u32` value");
+            if n > m {
+                Err(FrequencyParseError::NGreaterThanM)
+            } else {
+                Ok(Self::Ratio { n, m })
+            }
         } else if let Some(cap) = FREQUENCY_PT.captures(s) {
             let frequency: f64 = cap["frequency"]
                 .parse()
                 .expect("Regexp pattern should ensure that frequency is parsable into f64");
             if (0. ..=100.).contains(&frequency) {
-                Ok(Frequency::Frequency(frequency))
+                Ok(Self::Percentage(frequency))
             } else {
                 Err(FrequencyParseError::FrequencyOutOfBounds)
             }
         } else {
             // Fall back to TermId
-            match s.parse().map(Frequency::TermId) {
+            match s.parse().map(Self::TermId) {
                 Ok(frequency) => Ok(frequency),
                 Err(_) => Err(FrequencyParseError::UnparsableValue),
             }
+        }
+    }
+}
+
+/// Format a `Frequency`.
+///
+/// # Examples
+///
+/// ```
+/// use ontolius::TermId;
+/// use oboannotation::hpo::Frequency;
+///
+/// let freq: Frequency = Frequency::TermId("HP:0040284".parse().unwrap());
+///
+/// assert_eq!(freq.to_string().as_str(), "HP:0040284");
+/// ```
+impl Display for Frequency {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TermId(t) => write!(f, "{}", t),
+            Self::Ratio { n, m } => write!(f, "{n}/{m}"),
+            Self::Percentage(percentage) => write!(f, "{:.1}%", percentage),
         }
     }
 }
@@ -287,25 +326,11 @@ mod test_frequency {
     }
 
     #[test]
-    fn from_str_ratio() {
-        let f: Result<Frequency, _> = "1/44".parse();
-        assert!(f.is_ok());
+    fn from_str_freq_bad_ratio() {
+        let f: Result<Frequency, _> = "13/7".parse();
+        assert!(f.is_err());
 
-        assert_eq!(
-            f.unwrap(),
-            Frequency::Ratio {
-                numerator: 1,
-                denominator: 44
-            }
-        );
-    }
-
-    #[test]
-    fn from_str_frequency() {
-        let f: Result<Frequency, _> = "54.11%".parse();
-        assert!(f.is_ok());
-
-        assert_eq!(f.unwrap(), Frequency::Frequency(54.11));
+        assert_eq!(f.unwrap_err(), FrequencyParseError::NGreaterThanM);
     }
 
     #[test]
@@ -318,14 +343,6 @@ mod test_frequency {
             "100.01%".parse::<Frequency>().unwrap_err(),
             FrequencyParseError::FrequencyOutOfBounds
         );
-    }
-
-    #[test]
-    fn from_str_term_id() {
-        let f: Result<Frequency, _> = "HP:0040284".parse();
-        assert!(f.is_ok());
-
-        assert_eq!(f.unwrap(), Frequency::TermId("HP:0040284".parse().unwrap()));
     }
 
     #[test]
@@ -353,29 +370,54 @@ pub struct HpoAnnotation {
     pub curators: Vec<String>,
 }
 
+/// The HPO annotation corpus with entries parsed to the highest level possible
+/// while making no wild assumptions about the parsed data.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HpoAnnotations {
+    /// The HPO annotation records.
+    pub lines: Vec<HpoAnnotation>,
+    /// The HPOA version (e.g. `2023-04-05`)
+    pub version: String,
+    pub hpo_version: String,
+}
+
 /// Parse disease-phenotype annotations from HPO annotation file.
 pub mod io {
-    use ontolius::TermIdParseError;
-    use regex::Regex;
-    use std::fmt::{Debug, Display};
-    use std::fs::File;
-    use std::io::{BufRead, BufReader, Read, Write};
-    use std::path::Path;
-
     use super::{
         AnnotationReference, Aspect, EvidenceCode, Frequency, FrequencyParseError, HpoAnnotation,
-        Sex,
+        HpoAnnotations, Sex,
     };
+    use crate::io::{AnnotationWriter, ReadAnnotation};
     use crate::{
         format::Hpoa,
         io::{AnnotationLoadError, AnnotationLoader, ValidationIssue, WriteAnnotation},
     };
+    use ontolius::{Prefix, TermIdParseError};
+    use regex::Regex;
+    use std::collections::BTreeMap;
+    use std::fmt::{Debug, Display};
+    use std::io::{BufRead, Write};
+    use std::sync::LazyLock;
 
-    const HPOA_COLUMN_COUNT: usize = 12;
+    const HPOA_HEADER: [&str; 12] = [
+        "database_id",
+        "disease_name",
+        "qualifier",
+        "hpo_id",
+        "reference",
+        "evidence",
+        "onset",
+        "frequency",
+        "sex",
+        "modifier",
+        "aspect",
+        "biocuration",
+    ];
 
-    /// HPOA is a tab-delimited table ...
-    const DELIMITER: &str = "\t";
-    /// ... with 12 columns.
+    // HPOA is a tab-delimited table ...
+    const HPOA_DELIMITER: &str = "\t";
+    // ... with 12 columns.
+    const HPOA_COLUMN_COUNT: usize = HPOA_HEADER.len();
     const DISEASE_ID_COL_IDX: usize = 0;
     const DISEASE_NAME_COL_IDX: usize = 1;
     const NEGATED_COL_IDX: usize = 2;
@@ -411,7 +453,7 @@ pub mod io {
         }
     }
 
-    impl std::fmt::Display for HpoaError<'_> {
+    impl Display for HpoaError<'_> {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             match &self.reason {
                 HpoaErrorReason::InvalidDiseaseId(e) => {
@@ -452,6 +494,11 @@ pub mod io {
                         "Unparsable frequency value: {}",
                         self.fields[FREQUENCY_COL_IDX]
                     ),
+                    FrequencyParseError::NGreaterThanM => write!(
+                        f,
+                        "`n` is greater than `m`: {}",
+                        self.fields[FREQUENCY_COL_IDX]
+                    ),
                 },
                 HpoaErrorReason::InvalidModifier(i, _e) => write!(
                     f,
@@ -477,7 +524,7 @@ pub mod io {
     /// The reasons for failure in parsing of HPO annotation line in [`HpoAnnotation::parse_hpoa_line`].
     #[derive(Debug, thiserror::Error, PartialEq)]
     pub enum HpoaErrorReason {
-        #[error("Cannot parse a record with {0}!={HPOA_COLUMN_COUNT}")]
+        #[error("Cannot parse a record with {0}!={col_cnt}", col_cnt=HPOA_COLUMN_COUNT)]
         InvalidFieldCount(usize),
         #[error("Invalid disease identifier: {0}")]
         InvalidDiseaseId(TermIdParseError),
@@ -495,63 +542,112 @@ pub mod io {
         InvalidAspect,
     }
 
-    /// Loader for HPO annotations.
+    impl AnnotationWriter<Hpoa> for &HpoAnnotations {
+        type Err = std::io::Error;
+
+        fn store_to_write<W>(self, mut write: W) -> Result<(), Self::Err>
+        where
+            W: Write,
+        {
+            // Comments
+            // #description: "HPO annotations for rare diseases [8362: OMIM; 47: DECIPHER; 4283 ORPHANET]"
+            let disease_counts = count_diseases(&self.lines);
+            write!(
+                &mut write,
+                "#description: \"HPO annotations for rare diseases"
+            )?;
+            if let Some((first, rest)) = disease_counts.split_first() {
+                write!(&mut write, " [{}: {}", first.1, first.0)?;
+
+                for (prefix, cnt) in rest {
+                    write!(&mut write, "; {}: {}", cnt, prefix)?;
+                }
+
+                writeln!(&mut write, "]\"")?;
+            } else {
+                writeln!(&mut write, "\"")?;
+            }
+            // versions, tracker
+            writeln!(&mut write, "#version: {}", self.version)?;
+            writeln!(
+                &mut write,
+                "#tracker: https://github.com/obophenotype/human-phenotype-ontology/issues"
+            )?;
+            writeln!(
+                &mut write,
+                "#hpo-version: https://purl.obolibrary.org/obo/hp/releases/{}/hp.json",
+                self.hpo_version
+            )?;
+
+            // header
+            if let Some((first, rest)) = HPOA_HEADER.split_first() {
+                write!(&mut write, "{first}")?;
+                for val in rest {
+                    write!(&mut write, "{}{}", HPOA_DELIMITER, val)?;
+                }
+            }
+            writeln!(&mut write)?;
+
+            // lines
+            for line in &self.lines {
+                line.write_ann(&mut write)?;
+            }
+
+            Ok(())
+        }
+    }
+
+    fn count_diseases(lines: &[HpoAnnotation]) -> Vec<(Prefix<'_>, u32)> {
+        let mut counts = BTreeMap::new();
+
+        for ann in lines {
+            *counts.entry(ann.disease_id.prefix()).or_default() += 1;
+        }
+
+        counts.into_iter().collect()
+    }
+
+    // #version: 2025-05-06
+    static HPOA_VERSION_PT: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"^#(date|version): (?<version>[\w-]+)\w?$")
+            .expect("Default pattern should be valid")
+    });
+
+    // #hpo-version: http://purl.obolibrary.org/obo/hp/releases/2025-05-06/hp.json
+    static HPO_VERSION_PT: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"^#hpo-version: (http|https)://[\w./]+/(?<version>\d{4}-\d{2}-\d{2})/hp\.json$")
+            .expect("Default pattern should be valid")
+    });
+
+    /// Load the phenotype-disease annotations from HPO annotation file.
     ///
-    /// ## Examples
+    /// # Example
     ///
     /// ```
-    /// use oboannotation::hpo::io::HpoAnnotationLoader;
     /// use oboannotation::io::AnnotationLoader;
+    /// use oboannotation::hpo::HpoAnnotations;
     ///
-    /// let loader = HpoAnnotationLoader::default();
-    ///
-    /// let data = loader.load_from_path("data/phenotype.real-shortlist.hpoa")
+    /// let data = HpoAnnotations::load_from_path("data/phenotype.real-shortlist.hpoa")
     ///              .expect("The example data should be well formatted");
     ///
     /// // Loaded HPO annotations version `2023-04-05` ...
     /// assert_eq!(data.version.as_str(), "2023-04-05");
     ///
+    /// // ... generated with HPO version `2023-04-05` ...
+    /// assert_eq!(data.hpo_version.as_str(), "2023-04-05");
+    ///
     /// // ... consisting of 86 lines.
     /// assert_eq!(data.lines.len(), 86);
     /// ```
-    pub struct HpoAnnotationLoader {
-        version_pt: Regex,
-    }
-
-    impl Default for HpoAnnotationLoader {
-        fn default() -> Self {
-            Self {
-                version_pt: Regex::new(r"^#(date|version): (?<version>[\w-]+)\w?$")
-                    .expect("Default pattern should be valid"),
-            }
-        }
-    }
-
-    impl AnnotationLoader<HpoAnnotationLines> for HpoAnnotationLoader {
-        fn load_from_path<P>(&self, path: P) -> Result<HpoAnnotationLines, AnnotationLoadError>
-        where
-            P: AsRef<Path>,
-        {
-            self.load_from_read(File::open(path)?)
-        }
-
-        fn load_from_read<R>(&self, read: R) -> Result<HpoAnnotationLines, AnnotationLoadError>
-        where
-            R: Read,
-        {
-            self.load_from_buf_read(BufReader::new(read))
-        }
-
-        fn load_from_buf_read<R>(
-            &self,
-            mut read: R,
-        ) -> Result<HpoAnnotationLines, AnnotationLoadError>
+    impl AnnotationLoader<Hpoa> for HpoAnnotations {
+        fn load_from_buf_read<R>(mut read: R) -> Result<HpoAnnotations, AnnotationLoadError>
         where
             R: BufRead,
         {
             let mut lines = vec![];
             let mut errors = vec![];
             let mut version = None;
+            let mut hpo_version = None;
 
             let mut line = String::new();
             let mut expecting_header = true;
@@ -568,16 +664,16 @@ pub mod io {
                             // Header
                             if line.starts_with("#DatabaseID") || line.starts_with("database_id") {
                                 expecting_header = false;
-                            } else if let Some(caps) = self.version_pt.captures(line.trim()) {
+                            } else if let Some(caps) = HPOA_VERSION_PT.captures(line.trim()) {
                                 version = Some(caps["version"].to_string());
+                            } else if let Some(caps) = HPO_VERSION_PT.captures(line.trim()) {
+                                hpo_version = Some(caps["version"].to_string());
                             }
                         } else {
                             // Data
-                            match HpoAnnotation::parse_hpoa_line(&line) {
+                            match HpoAnnotation::read_str(&line) {
                                 Ok(hal) => lines.push(hal),
-                                Err(e) => {
-                                    errors.push(ValidationIssue::new(line_number, &e));
-                                }
+                                Err(e) => errors.push(ValidationIssue::new(line_number, &e)),
                             }
                         }
                     }
@@ -589,10 +685,15 @@ pub mod io {
 
             if !errors.is_empty() {
                 Err(AnnotationLoadError::ValidationError(errors))
-            } else if let Some(version) = version {
-                Ok(HpoAnnotationLines { lines, version })
             } else {
-                Err(AnnotationLoadError::Error("Missing version".into()))
+                match (version, hpo_version) {
+                    (Some(v), Some(hv)) => Ok(HpoAnnotations {
+                        lines,
+                        version: v,
+                        hpo_version: hv,
+                    }),
+                    _ => Err(AnnotationLoadError::Error("Missing version".into())),
+                }
             }
         }
     }
@@ -600,7 +701,7 @@ pub mod io {
     impl WriteAnnotation<Hpoa> for HpoAnnotation {
         fn write_ann<W>(&self, w: &mut W) -> std::io::Result<()>
         where
-            W: Write
+            W: Write,
         {
             // database_id, disease_name
             write!(w, "{}\t{}\t", self.disease_id, self.disease_name)?;
@@ -660,60 +761,24 @@ pub mod io {
 
             // biocuration
             write_semicolon_separated_array(w, &self.curators)?;
-            write!(w, "\n")?;
+            writeln!(w,)?;
 
             Ok(())
         }
     }
 
-    #[cfg(test)]
-    mod test_hpo_annotation_write {
-        use super::hpoa_examples::{make_complex_hpo_annotation, make_simple_hpo_annotation};
-        use crate::format::Hpoa;
-        use crate::hpo::HpoAnnotation;
-        use crate::io::WriteAnnotation;
+    /// Parse HPO annotation line into `HpoAnnotation`.
+    ///
+    /// # Errors
+    ///
+    /// Parsing fails on malformed HPO annotation line.
+    /// See [`HpoaErrorReason`] for the possible causes.
+    ///
+    impl ReadAnnotation<Hpoa> for HpoAnnotation {
+        type Err = HpoaErrorReason;
 
-        #[test]
-        fn test_write_complex_hpo_annotation() -> std::io::Result<()> {
-            let a = make_complex_hpo_annotation();
-
-            let mut buf = Vec::new();
-            <HpoAnnotation as WriteAnnotation<Hpoa>>::write_ann(&a, &mut buf)?;
-
-            let line = str::from_utf8(&buf).unwrap();
-            assert_eq!(
-                line,
-                "OMIM:303110\tXq21 deletion syndrome\tNOT\tHP:0000365\tPMID:3476958\tPCS\tHP:0003577\t4/8\tMALE\tHP:0012828\tP\tHPO:iea[2009-02-17];HPO:probinson[2021-09-27];HPO:probinson[2021-09-27]\n"
-            );
-            Ok(())
-        }
-
-        #[test]
-        fn test_write_simple_hpo_annotation() -> std::io::Result<()> {
-            let a = make_simple_hpo_annotation();
-
-            let mut buf = Vec::new();
-            <HpoAnnotation as WriteAnnotation<Hpoa>>::write_ann(&a, &mut buf)?;
-
-            let line = str::from_utf8(&buf).unwrap();
-            assert_eq!(
-                line,
-                "OMIM:303110\tXq21 deletion syndrome\t\tHP:0001419\t\t\t\t\t\t\tI\t\n"
-            );
-            Ok(())
-        }
-    }
-
-    impl HpoAnnotation {
-        /// Parse HPO annotation line into `HpoAnnotation`.
-        ///
-        /// # Errors
-        ///
-        /// Parsing fails on malformed HPO annotation line.
-        /// See [`HpoaErrorReason`] for the possible causes.
-        ///
-        pub fn parse_hpoa_line(s: &str) -> Result<Self, HpoaErrorReason> {
-            let fields: Vec<_> = s.trim().split(DELIMITER).collect();
+        fn read_str(val: &str) -> Result<Self, Self::Err> {
+            let fields: Vec<_> = val.trim().split(HPOA_DELIMITER).collect();
             if fields.len() == HPOA_COLUMN_COUNT {
                 // Disease ID
                 let disease_id = fields[DISEASE_ID_COL_IDX]
@@ -749,7 +814,8 @@ pub mod io {
                     Err(e) => match e {
                         FrequencyParseError::EmptyVal => None,
                         FrequencyParseError::FrequencyOutOfBounds
-                        | FrequencyParseError::UnparsableValue => {
+                        | FrequencyParseError::UnparsableValue
+                        | FrequencyParseError::NGreaterThanM => {
                             return Err(HpoaErrorReason::InvalidFrequency(e));
                         }
                     },
@@ -794,29 +860,65 @@ pub mod io {
         }
     }
 
-    /// The HPO annotation corpus with entries parsed to the highest level possible
-    /// while making no wild assumptions about the parsed data.
-    #[derive(Debug, Clone)]
-    pub struct HpoAnnotationLines {
-        /// The HPO annotation records.
-        pub lines: Vec<HpoAnnotation>,
-        /// The HPOA version (e.g. `2023-04-05`)
-        pub version: String,
-    }
-
     #[cfg(test)]
     mod test_hpo_io {
-        use ontolius::TermIdParseError;
-
+        use super::{HpoAnnotation, HpoAnnotations, HpoaErrorReason};
+        use crate::format::Hpoa;
+        use crate::hpo::io::hpoa_examples::{
+            make_complex_hpo_annotation, make_hpo_annotations, make_simple_hpo_annotation,
+        };
         use crate::hpo::{AnnotationReference, Aspect, EvidenceCode, Frequency};
-
-        use super::{HpoAnnotation, HpoaErrorReason};
+        use crate::io::{AnnotationLoader, AnnotationWriter, ReadAnnotation, WriteAnnotation};
+        use ontolius::TermIdParseError;
+        use std::io::BufRead;
 
         #[test]
-        fn parse_hpoa_line_ok() {
+        fn write_hpo_annotations() -> Result<(), Box<dyn std::error::Error>> {
+            let anns = make_hpo_annotations();
+
+            let mut w = Vec::new();
+            anns.store_to_write(&mut w)?;
+
+            let lines: Vec<_> = w.lines().map(|l| l.unwrap()).collect();
+            assert_eq!(
+                &lines,
+                &[
+                    "#description: \"HPO annotations for rare diseases [4: OMIM; 4: ORPHA]\"",
+                    "#version: 2025-05-06",
+                    "#tracker: https://github.com/obophenotype/human-phenotype-ontology/issues",
+                    "#hpo-version: https://purl.obolibrary.org/obo/hp/releases/2025-05-06/hp.json",
+                    "database_id\tdisease_name\tqualifier\thpo_id\treference\tevidence\tonset\tfrequency\tsex\tmodifier\taspect\tbiocuration",
+                    "OMIM:154700\tMarfan syndrome\t\tHP:0002616\tPMID:33436942\tPCS\t\t45/58\t\t\tP\tHPO:probinson[2012-04-24];HPO:probinson[2021-04-01]",
+                    "OMIM:154700\tMarfan syndrome\t\tHP:0001647\tPMID:33436942\tPCS\t\t1/58\t\t\tP\tHPO:probinson[2021-04-01]",
+                    "OMIM:154700\tMarfan syndrome\t\tHP:0000678\tPMID:33436942\tPCS\t\t8/53\t\t\tP\tHPO:probinson[2012-04-24];HPO:probinson[2021-04-01]",
+                    "OMIM:154700\tMarfan syndrome\t\tHP:0008138\tPMID:28050285\tPCS\t\t31/146\t\t\tP\tHPO:probinson[2021-05-27]",
+                    "ORPHA:79414\tWoolly hair nevus\t\tHP:0002212\tORPHA:79414\tTAS\t\tHP:0040281\t\t\tP\tORPHA:orphadata[2025-05-06]",
+                    "ORPHA:79414\tWoolly hair nevus\t\tHP:0002213\tORPHA:79414\tTAS\t\tHP:0040281\t\t\tP\tORPHA:orphadata[2025-05-06]",
+                    "ORPHA:79414\tWoolly hair nevus\t\tHP:0011365\tORPHA:79414\tTAS\t\tHP:0040281\t\t\tP\tORPHA:orphadata[2025-05-06]",
+                    "ORPHA:79414\tWoolly hair nevus\t\tHP:0040149\tORPHA:79414\tTAS\t\tHP:0040281\t\t\tP\tORPHA:orphadata[2025-05-06]",
+                ]
+            );
+            Ok(())
+        }
+
+        #[test]
+        fn roundtrip_hpo_annotations() -> Result<(), Box<dyn std::error::Error>> {
+            let expected = make_hpo_annotations();
+
+            let mut w = Vec::new();
+            expected.store_to_write(&mut w)?;
+
+            let actual = HpoAnnotations::load_from_buf_read(&mut &w[..])?;
+
+            assert_eq!(actual, expected);
+            Ok(())
+        }
+
+        #[test]
+        fn read_hpoa_str_line_ok() {
             let line = "OMIM:154700\tMarfan syndrome\t\tHP:0001377\tPMID:28050285;PMID:33436942\tPCS\t\t29/199\t\t\tP\tHPO:probinson[2021-05-27];HPO:probinson[2021-04-01]";
 
-            let hpo_line: Result<HpoAnnotation, _> = HpoAnnotation::parse_hpoa_line(line);
+            let hpo_line: Result<HpoAnnotation, _> = HpoAnnotation::read_str(line);
 
             assert!(hpo_line.is_ok());
 
@@ -836,10 +938,7 @@ pub mod io {
             assert_eq!(hpo_line.frequency.is_some(), true);
             assert_eq!(
                 &hpo_line.frequency.unwrap(),
-                &Frequency::Ratio {
-                    numerator: 29,
-                    denominator: 199
-                }
+                &Frequency::Ratio { n: 29, m: 199 }
             );
 
             assert!(hpo_line.sex.is_none());
@@ -855,9 +954,9 @@ pub mod io {
         }
 
         #[test]
-        fn parse_hpoa_line_bad_disease_id() {
+        fn read_str_bad_disease_id() {
             let line = "OMIM-154700\tMarfan syndrome\t\tHP:0001377\tPMID:28050285;PMID:33436942\tPCS\t\t29/199\t\t\tP\tHPO:probinson[2021-05-27];HPO:probinson[2021-04-01]";
-            let hpo_line: Result<_, _> = HpoAnnotation::parse_hpoa_line(line);
+            let hpo_line: Result<_, _> = HpoAnnotation::read_str(line);
 
             assert!(hpo_line.is_err());
             assert_eq!(
@@ -865,13 +964,45 @@ pub mod io {
                 HpoaErrorReason::InvalidDiseaseId(TermIdParseError::MissingDelimiter)
             );
         }
+
+        #[test]
+        fn test_write_complex_hpo_annotation() -> std::io::Result<()> {
+            let a = make_complex_hpo_annotation();
+
+            let mut buf = Vec::new();
+            <HpoAnnotation as WriteAnnotation<Hpoa>>::write_ann(&a, &mut buf)?;
+
+            let line = str::from_utf8(&buf).unwrap();
+            assert_eq!(
+                line,
+                "OMIM:303110\tXq21 deletion syndrome\tNOT\tHP:0000365\tPMID:3476958\tPCS\tHP:0003577\t4/8\tMALE\tHP:0012828\tP\tHPO:iea[2009-02-17];HPO:probinson[2021-09-27];HPO:probinson[2021-09-27]\n"
+            );
+            Ok(())
+        }
+
+        #[test]
+        fn test_write_simple_hpo_annotation() -> std::io::Result<()> {
+            let a = make_simple_hpo_annotation();
+
+            let mut buf = Vec::new();
+            <HpoAnnotation as WriteAnnotation<Hpoa>>::write_ann(&a, &mut buf)?;
+
+            let line = str::from_utf8(&buf).unwrap();
+            assert_eq!(
+                line,
+                "OMIM:303110\tXq21 deletion syndrome\t\tHP:0001419\t\t\t\t\t\t\tI\t\n"
+            );
+            Ok(())
+        }
     }
 
     #[cfg(test)]
     mod hpoa_examples {
+        use crate::hpo::io::HpoAnnotations;
         use crate::hpo::{
             AnnotationReference, Aspect, EvidenceCode, Frequency, HpoAnnotation, Sex,
         };
+        use crate::io::ReadAnnotation;
 
         pub(super) fn make_complex_hpo_annotation() -> HpoAnnotation {
             HpoAnnotation {
@@ -884,10 +1015,7 @@ pub mod io {
                     EvidenceCode::PCS,
                 )],
                 onset: Some(("HP", "0003577").into()),
-                frequency: Some(Frequency::Ratio {
-                    numerator: 4,
-                    denominator: 8,
-                }),
+                frequency: Some(Frequency::Ratio { n: 4, m: 8 }),
                 sex: Some(Sex::Male),
                 modifiers: vec![("HP", "0012828").into()],
                 aspect: Aspect::Phenotype,
@@ -914,8 +1042,37 @@ pub mod io {
                 curators: vec![],
             }
         }
-    }
 
+        pub(super) fn make_hpo_annotations() -> HpoAnnotations {
+            let mut lines = Vec::new();
+            lines.extend(marfan_annotations());
+            lines.extend(wooly_annotations());
+            HpoAnnotations {
+                lines,
+                version: "2025-05-06".to_string(),
+                hpo_version: "2025-05-06".to_string(),
+            }
+        }
+        fn marfan_annotations() -> impl Iterator<Item = HpoAnnotation> {
+            [
+                "OMIM:154700\tMarfan syndrome\t\tHP:0002616\tPMID:33436942\tPCS\t\t45/58\t\t\tP\tHPO:probinson[2012-04-24];HPO:probinson[2021-04-01]",
+                "OMIM:154700\tMarfan syndrome\t\tHP:0001647\tPMID:33436942\tPCS\t\t1/58\t\t\tP\tHPO:probinson[2021-04-01]",
+                "OMIM:154700\tMarfan syndrome\t\tHP:0000678\tPMID:33436942\tPCS\t\t8/53\t\t\tP\tHPO:probinson[2012-04-24];HPO:probinson[2021-04-01]",
+                "OMIM:154700\tMarfan syndrome\t\tHP:0008138\tPMID:28050285\tPCS\t\t31/146\t\t\tP\tHPO:probinson[2021-05-27]",
+            ].into_iter()
+                .map(|line| HpoAnnotation::read_str(line).unwrap())
+        }
+
+        fn wooly_annotations() -> impl Iterator<Item = HpoAnnotation> {
+            [
+                "ORPHA:79414\tWoolly hair nevus\t\tHP:0002212\tORPHA:79414\tTAS\t\tHP:0040281\t\t\tP\tORPHA:orphadata[2025-05-06]",
+                "ORPHA:79414\tWoolly hair nevus\t\tHP:0002213\tORPHA:79414\tTAS\t\tHP:0040281\t\t\tP\tORPHA:orphadata[2025-05-06]",
+                "ORPHA:79414\tWoolly hair nevus\t\tHP:0011365\tORPHA:79414\tTAS\t\tHP:0040281\t\t\tP\tORPHA:orphadata[2025-05-06]",
+                "ORPHA:79414\tWoolly hair nevus\t\tHP:0040149\tORPHA:79414\tTAS\t\tHP:0040281\t\t\tP\tORPHA:orphadata[2025-05-06]",
+            ].into_iter()
+                .map(|line| HpoAnnotation::read_str(line).unwrap())
+        }
+    }
 
     fn format_sex<W>(w: &mut W, sex: &Sex) -> std::io::Result<()>
     where
@@ -932,14 +1089,7 @@ pub mod io {
     where
         W: Write,
     {
-        match frequency {
-            Frequency::TermId(term_id) => write!(w, "{}", term_id),
-            Frequency::Ratio {
-                numerator,
-                denominator,
-            } => write!(w, "{}/{}", numerator, denominator),
-            Frequency::Frequency(freq) => write!(w, "{:.1}%", freq * 100f64),
-        }
+        write!(w, "{frequency}")
     }
 
     fn write_annotation_reference_evidence_code<W>(

--- a/src/hpo.rs
+++ b/src/hpo.rs
@@ -808,10 +808,101 @@ impl HpoAnnotationBuilder<Set, Set, Set> {
 #[derive(Debug, Clone, PartialEq)]
 pub struct HpoAnnotations {
     /// The HPO annotation records.
-    pub lines: Vec<HpoAnnotation>,
+    lines: Vec<HpoAnnotation>,
     /// The HPOA version (e.g. `2023-04-05`)
-    pub version: String,
-    pub hpo_version: String,
+    version: String,
+    hpo_version: String,
+}
+
+impl HpoAnnotations {
+    /// Create builder for building the annotations.
+    pub fn builder() -> HpoAnnotationsBuilder<Unset, Unset> {
+        HpoAnnotationsBuilder {
+            lines: vec![],
+            version: None,
+            hpo_version: None,
+            state: PhantomData,
+        }
+    }
+
+    /// Get the HPO annotations
+    pub fn annotations(&self) -> &[HpoAnnotation] {
+        self.lines.as_slice()
+    }
+
+    /// Get HPO annotation version.
+    pub fn version(&self) -> &str {
+        self.version.as_str()
+    }
+
+    /// Get version of HPO used to build the annotations.
+    pub fn hpo_version(&self) -> &str {
+        self.hpo_version.as_str()
+    }
+}
+
+/// Builder for [`HpoAnnotations`].
+pub struct HpoAnnotationsBuilder<A, B> {
+    lines: Vec<HpoAnnotation>,
+    version: Option<String>,
+    hpo_version: Option<String>,
+    state: PhantomData<(A, B)>,
+}
+
+impl<A, B> HpoAnnotationsBuilder<A, B> {
+    /// Add an annotation.
+    pub fn add_annotation(mut self, annotation: impl Into<HpoAnnotation>) -> Self {
+        self.lines.push(annotation.into());
+        self
+    }
+
+    /// Add several annotations.
+    pub fn extend_annotations(
+        mut self,
+        annotations: impl IntoIterator<Item = HpoAnnotation>,
+    ) -> Self {
+        self.lines.extend(annotations);
+        self
+    }
+}
+
+impl<A> HpoAnnotationsBuilder<A, Unset> {
+    /// Indicate which HPO version was used to build the annotations.
+    pub fn hpo_version(self, hpo_version: impl Into<String>) -> HpoAnnotationsBuilder<A, Set> {
+        HpoAnnotationsBuilder {
+            lines: self.lines,
+            version: self.version,
+            hpo_version: Some(hpo_version.into()),
+            state: PhantomData,
+        }
+    }
+}
+
+impl<B> HpoAnnotationsBuilder<Unset, B> {
+    /// Set HPO annotation version.
+    pub fn hpoa_version(self, version: impl Into<String>) -> HpoAnnotationsBuilder<Set, B> {
+        HpoAnnotationsBuilder {
+            lines: self.lines,
+            version: Some(version.into()),
+            hpo_version: self.hpo_version,
+            state: PhantomData,
+        }
+    }
+}
+
+impl HpoAnnotationsBuilder<Set, Set> {
+    /// Build the HPO annotations.
+    pub fn build(self) -> HpoAnnotations {
+        HpoAnnotations {
+            lines: self.lines,
+            version: self
+                .version
+                .expect("Build can be called only after version is set"),
+            hpo_version: self
+                .hpo_version
+                .expect("Build can be called only after HPO version is set"),
+        }
+    }
 }
 
 /// Parse disease-phenotype annotations from HPO annotation file.
@@ -1065,13 +1156,13 @@ pub mod io {
     ///              .expect("The example data should be well formatted");
     ///
     /// // Loaded HPO annotations version `2023-04-05` ...
-    /// assert_eq!(data.version.as_str(), "2023-04-05");
+    /// assert_eq!(data.version(), "2023-04-05");
     ///
     /// // ... generated with HPO version `2023-04-05` ...
-    /// assert_eq!(data.hpo_version.as_str(), "2023-04-05");
+    /// assert_eq!(data.hpo_version(), "2023-04-05");
     ///
     /// // ... consisting of 86 lines.
-    /// assert_eq!(data.lines.len(), 86);
+    /// assert_eq!(data.annotations().len(), 86);
     /// ```
     impl AnnotationLoader<Hpoa> for HpoAnnotations {
         fn load_from_buf_read<R>(mut read: R) -> Result<HpoAnnotations, AnnotationLoadError>

--- a/src/hpo.rs
+++ b/src/hpo.rs
@@ -64,7 +64,7 @@ pub enum Aspect {
     /// Inheritance.
     Inheritance,
     /// Onset and clinical course.
-    ClinicalModifier,
+    ClinicalCourse,
     /// Modifier.
     Modifier,
     /// Past medical history.
@@ -86,7 +86,7 @@ impl TryFrom<char> for Aspect {
         match value {
             'P' | 'p' => Ok(Aspect::Phenotype),
             'I' | 'i' => Ok(Aspect::Inheritance),
-            'C' | 'c' => Ok(Aspect::ClinicalModifier),
+            'C' | 'c' => Ok(Aspect::ClinicalCourse),
             'M' | 'm' => Ok(Aspect::Modifier),
             'H' | 'h' => Ok(Aspect::PastMedicalHistory),
             _ => Err("Unknown aspect code"),
@@ -355,14 +355,20 @@ pub struct HpoAnnotation {
 
 /// Parse disease-phenotype annotations from HPO annotation file.
 pub mod io {
-    use std::io::BufRead;
-
     use ontolius::TermIdParseError;
     use regex::Regex;
+    use std::fmt::{Debug, Display};
+    use std::fs::File;
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::path::Path;
 
+    use super::{
+        AnnotationReference, Aspect, EvidenceCode, Frequency, FrequencyParseError, HpoAnnotation,
+        Sex,
+    };
     use crate::{
-        hpo::{AnnotationReference, Aspect, EvidenceCode, FrequencyParseError, HpoAnnotation},
-        io::{AnnotationLoadError, AnnotationLoader, ValidationIssue},
+        format::Hpoa,
+        io::{AnnotationLoadError, AnnotationLoader, ValidationIssue, WriteAnnotation},
     };
 
     const HPOA_COLUMN_COUNT: usize = 12;
@@ -522,6 +528,20 @@ pub mod io {
     }
 
     impl AnnotationLoader<HpoAnnotationLines> for HpoAnnotationLoader {
+        fn load_from_path<P>(&self, path: P) -> Result<HpoAnnotationLines, AnnotationLoadError>
+        where
+            P: AsRef<Path>,
+        {
+            self.load_from_read(File::open(path)?)
+        }
+
+        fn load_from_read<R>(&self, read: R) -> Result<HpoAnnotationLines, AnnotationLoadError>
+        where
+            R: Read,
+        {
+            self.load_from_buf_read(BufReader::new(read))
+        }
+
         fn load_from_buf_read<R>(
             &self,
             mut read: R,
@@ -575,19 +595,112 @@ pub mod io {
                 Err(AnnotationLoadError::Error("Missing version".into()))
             }
         }
+    }
 
-        fn load_from_path<P>(&self, path: P) -> Result<HpoAnnotationLines, AnnotationLoadError>
+    impl WriteAnnotation<Hpoa> for HpoAnnotation {
+        fn write_ann<W>(&self, w: &mut W) -> std::io::Result<()>
         where
-            P: AsRef<std::path::Path>,
+            W: Write
         {
-            self.load_from_read(std::fs::File::open(path)?)
+            // database_id, disease_name
+            write!(w, "{}\t{}\t", self.disease_id, self.disease_name)?;
+
+            // qualifier
+            if self.is_negated {
+                write!(w, "NOT")?
+            }
+            write!(w, "\t")?;
+
+            // hpo_id
+            write!(w, "{}\t", self.phenotype_term_id)?;
+
+            // reference, evidence
+            if let Some((last, rest)) = self.annotation_references.split_last() {
+                for ar in rest.iter() {
+                    write!(w, "{};", ar.term_id)?;
+                }
+                write!(w, "{}\t", last.term_id)?;
+                write_annotation_reference_evidence_code(w, last.evidence_code)?;
+            } else {
+                write!(w, "\t")?
+            }
+            write!(w, "\t")?;
+
+            // onset
+            if let Some(onset) = &self.onset {
+                write!(w, "{}", onset)?;
+            }
+            write!(w, "\t")?;
+
+            // frequency
+            if let Some(frequency) = &self.frequency {
+                format_frequency(w, frequency)?;
+            }
+            write!(w, "\t")?;
+
+            // sex
+            if let Some(sex) = &self.sex {
+                format_sex(w, sex)?;
+            }
+            write!(w, "\t")?;
+
+            // modifier
+            write_semicolon_separated_array(w, &self.modifiers)?;
+            write!(w, "\t")?;
+
+            // aspect
+            match &self.aspect {
+                Aspect::Phenotype => write!(w, "P")?,
+                Aspect::Inheritance => write!(w, "I")?,
+                Aspect::ClinicalCourse => write!(w, "C")?,
+                Aspect::Modifier => write!(w, "M")?,
+                Aspect::PastMedicalHistory => write!(w, "H")?,
+            }
+            write!(w, "\t")?;
+
+            // biocuration
+            write_semicolon_separated_array(w, &self.curators)?;
+            write!(w, "\n")?;
+
+            Ok(())
+        }
+    }
+
+    #[cfg(test)]
+    mod test_hpo_annotation_write {
+        use super::hpoa_examples::{make_complex_hpo_annotation, make_simple_hpo_annotation};
+        use crate::format::Hpoa;
+        use crate::hpo::HpoAnnotation;
+        use crate::io::WriteAnnotation;
+
+        #[test]
+        fn test_write_complex_hpo_annotation() -> std::io::Result<()> {
+            let a = make_complex_hpo_annotation();
+
+            let mut buf = Vec::new();
+            <HpoAnnotation as WriteAnnotation<Hpoa>>::write_ann(&a, &mut buf)?;
+
+            let line = str::from_utf8(&buf).unwrap();
+            assert_eq!(
+                line,
+                "OMIM:303110\tXq21 deletion syndrome\tNOT\tHP:0000365\tPMID:3476958\tPCS\tHP:0003577\t4/8\tMALE\tHP:0012828\tP\tHPO:iea[2009-02-17];HPO:probinson[2021-09-27];HPO:probinson[2021-09-27]\n"
+            );
+            Ok(())
         }
 
-        fn load_from_read<R>(&self, read: R) -> Result<HpoAnnotationLines, AnnotationLoadError>
-        where
-            R: std::io::Read,
-        {
-            self.load_from_buf_read(std::io::BufReader::new(read))
+        #[test]
+        fn test_write_simple_hpo_annotation() -> std::io::Result<()> {
+            let a = make_simple_hpo_annotation();
+
+            let mut buf = Vec::new();
+            <HpoAnnotation as WriteAnnotation<Hpoa>>::write_ann(&a, &mut buf)?;
+
+            let line = str::from_utf8(&buf).unwrap();
+            assert_eq!(
+                line,
+                "OMIM:303110\tXq21 deletion syndrome\t\tHP:0001419\t\t\t\t\t\t\tI\t\n"
+            );
+            Ok(())
         }
     }
 
@@ -751,6 +864,110 @@ pub mod io {
                 hpo_line.unwrap_err(),
                 HpoaErrorReason::InvalidDiseaseId(TermIdParseError::MissingDelimiter)
             );
+        }
+    }
+
+    #[cfg(test)]
+    mod hpoa_examples {
+        use crate::hpo::{
+            AnnotationReference, Aspect, EvidenceCode, Frequency, HpoAnnotation, Sex,
+        };
+
+        pub(super) fn make_complex_hpo_annotation() -> HpoAnnotation {
+            HpoAnnotation {
+                disease_id: ("OMIM", "303110").into(),
+                disease_name: "Xq21 deletion syndrome".into(),
+                is_negated: true,
+                phenotype_term_id: ("HP", "0000365").into(), // Hearing impairment
+                annotation_references: vec![AnnotationReference::new(
+                    ("PMID", "3476958").into(),
+                    EvidenceCode::PCS,
+                )],
+                onset: Some(("HP", "0003577").into()),
+                frequency: Some(Frequency::Ratio {
+                    numerator: 4,
+                    denominator: 8,
+                }),
+                sex: Some(Sex::Male),
+                modifiers: vec![("HP", "0012828").into()],
+                aspect: Aspect::Phenotype,
+                curators: vec![
+                    "HPO:iea[2009-02-17]".into(),
+                    "HPO:probinson[2021-09-27]".into(),
+                    "HPO:probinson[2021-09-27]".into(),
+                ],
+            }
+        }
+
+        pub(super) fn make_simple_hpo_annotation() -> HpoAnnotation {
+            HpoAnnotation {
+                disease_id: ("OMIM", "303110").into(),
+                disease_name: "Xq21 deletion syndrome".into(),
+                is_negated: false,
+                phenotype_term_id: ("HP", "0001419").into(), // X-linked recessive inheritance
+                annotation_references: vec![],
+                onset: None,
+                frequency: None,
+                sex: None,
+                modifiers: vec![],
+                aspect: Aspect::Inheritance,
+                curators: vec![],
+            }
+        }
+    }
+
+
+    fn format_sex<W>(w: &mut W, sex: &Sex) -> std::io::Result<()>
+    where
+        W: Write,
+    {
+        match sex {
+            Sex::Unknown => write!(w, "UNKNOWN"),
+            Sex::Male => write!(w, "MALE"),
+            Sex::Female => write!(w, "FEMALE"),
+        }
+    }
+
+    fn format_frequency<W>(w: &mut W, frequency: &Frequency) -> std::io::Result<()>
+    where
+        W: Write,
+    {
+        match frequency {
+            Frequency::TermId(term_id) => write!(w, "{}", term_id),
+            Frequency::Ratio {
+                numerator,
+                denominator,
+            } => write!(w, "{}/{}", numerator, denominator),
+            Frequency::Frequency(freq) => write!(w, "{:.1}%", freq * 100f64),
+        }
+    }
+
+    fn write_annotation_reference_evidence_code<W>(
+        w: &mut W,
+        code: EvidenceCode,
+    ) -> std::io::Result<()>
+    where
+        W: Write,
+    {
+        match code {
+            EvidenceCode::IEA => write!(w, "IEA"),
+            EvidenceCode::TAS => write!(w, "TAS"),
+            EvidenceCode::PCS => write!(w, "PCS"),
+        }
+    }
+
+    fn write_semicolon_separated_array<W, T>(w: &mut W, a: &[T]) -> std::io::Result<()>
+    where
+        W: Write,
+        T: Display,
+    {
+        if let Some((last, rest)) = a.split_last() {
+            for x in rest {
+                write!(w, "{};", x)?;
+            }
+            write!(w, "{last}")
+        } else {
+            Ok(())
         }
     }
 }

--- a/src/hpo.rs
+++ b/src/hpo.rs
@@ -128,9 +128,16 @@ impl AnnotationReference {
     }
 }
 
-/// Frequency of a phenotypic abnormality.
+/// The ways to encode frequency of an HPO annotation.
+///
+/// The annotation frequency can be in one of the following forms:
+/// * [`FrequencyData::TermId`] - a term ID (e.g. [Obligate \[HP:0040280\]](https://hpo.jax.org/browse/term/HP:0040280))
+/// * [`FrequencyData::Ratio`] - an `n` over `m` (e.g. `7` out of `13` investigated individuals presented with the feature)
+/// * [`FrequencyData::Percentage`] - a percentage (e.g. 13% of the individuals presented with the feature)
+///
+/// The [`FrequencyData::Ratio`] is preferred over the other forms.
 #[derive(Debug, Clone, PartialEq)]
-pub enum Frequency {
+pub enum FrequencyData {
     /// Frequency data as [`TermId`], a member of HPO's
     /// [Frequency \[HP:0040279\]](https://hpo.jax.org/browse/term/HP:0040279) submodule.
     TermId(TermId),
@@ -142,6 +149,8 @@ pub enum Frequency {
     ///
     /// Note, that `1/2` and `2/4` do not represent the same information.
     /// The cohort size is `2` in the former while `4` individuals were investigated in the latter.
+    ///
+    /// `n` SHOULD be less than or equal to `m`.
     Ratio {
         /// Count of individuals with the annotation.
         n: u32,
@@ -153,12 +162,148 @@ pub enum Frequency {
     /// found to have the phenotypic abnormality referred to by the HPO term in question
     /// in the study referred to by the DB reference.
     ///
-    /// If possible, the 7/13 format (see [`Frequency::Ratio`]) is preferred over the percentage format
+    /// If possible, the 7/13 format (see [`FrequencyData::Ratio`]) is preferred over the percentage format
     /// if the exact data is available.
     ///
-    /// Should be a value in range of `[0..100]`. E.g. `7.` to represent 7%.
-    /// The range is, however, *NOT* enforced in any fashion!
+    /// The percentage SHOULD be a value in range of `[0..100]` (e.g. `7.` to represent 7%.).
     Percentage(f64),
+}
+
+impl From<TermId> for FrequencyData {
+    fn from(value: TermId) -> Self {
+        Self::TermId(value)
+    }
+}
+
+/// Frequency of a phenotypic abnormality.
+///
+/// The frequency is guaranteed to meet the following invariants:
+///
+/// * in [`FrequencyData::Ratio`], `n` is less than or equal to `m`
+/// * in [`FrequencyData::Percentage`], the value is in the range of \[0, 100\]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Frequency(FrequencyData);
+
+impl Frequency {
+    /// Get the frequency data.
+    pub fn data(&self) -> &FrequencyData {
+        &self.0
+    }
+
+    /// Create `Frequency` from `n` over `m`.
+    ///
+    ///
+    /// # Example
+    ///
+    /// Create frequency for annotation that was observed in `4` out of `8` tested individuals:
+    ///
+    /// ```
+    /// use oboannotation::hpo::{Frequency, FrequencyData};
+    ///
+    /// let freq: Result<Frequency, _> = Frequency::from_ratio(4u8, 8u8);
+    ///
+    /// assert!(freq.is_ok());
+    /// assert_eq!(freq.unwrap().data(), &FrequencyData::Ratio {n: 4, m: 8});
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Fails if `n` is greater than `m`:
+    ///
+    /// ```
+    /// use oboannotation::hpo::{Frequency, FrequencyData, FrequencyParseError};
+    ///
+    /// let freq: Result<Frequency, FrequencyParseError> = Frequency::from_ratio(9u8, 8u8);
+    ///
+    /// assert!(freq.is_err());
+    /// assert_eq!(freq.unwrap_err(), FrequencyParseError::NGreaterThanM);
+    /// ```
+    pub fn from_ratio(n: impl Into<u32>, m: impl Into<u32>) -> Result<Self, FrequencyParseError> {
+        let (n, m) = (n.into(), m.into());
+        if n <= m {
+            Ok(Self(FrequencyData::Ratio { n, m }))
+        } else {
+            Err(FrequencyParseError::NGreaterThanM)
+        }
+    }
+
+    /// Create `Frequency` from a percentage.
+    ///
+    /// # Example
+    ///
+    /// Create frequency for annotation that was observed in 49.5% of individuals:
+    ///
+    /// ```
+    /// use oboannotation::hpo::{Frequency, FrequencyData};
+    ///
+    /// let freq: Result<Frequency, _> = Frequency::from_percentage(49.5);
+    ///
+    /// assert!(freq.is_ok());
+    /// assert_eq!(freq.unwrap().data(), &FrequencyData::Percentage(49.5));
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Fails if the percentage is not in range of \[0, 100\]:
+    ///
+    /// ```
+    /// use oboannotation::hpo::{Frequency, FrequencyData, FrequencyParseError};
+    ///
+    /// let freq: Result<Frequency, FrequencyParseError> = Frequency::from_percentage(100.01);
+    ///
+    /// assert!(freq.is_err());
+    /// assert_eq!(freq.unwrap_err(), FrequencyParseError::PercentageOutOfBounds);
+    /// ```
+    pub fn from_percentage(percentage: impl Into<f64>) -> Result<Self, FrequencyParseError> {
+        let percentage = percentage.into();
+
+        if f64::is_sign_positive(percentage) && percentage <= 100.0 {
+            Ok(Self(FrequencyData::Percentage(percentage)))
+        } else {
+            Err(FrequencyParseError::PercentageOutOfBounds)
+        }
+    }
+}
+
+/// Format the frequency.
+///
+/// # Examples
+///
+/// ```
+/// use ontolius::TermId;
+/// use oboannotation::hpo::Frequency;
+///
+/// let freq: Frequency = Frequency::from_ratio(7u8, 13u8).unwrap();
+///
+/// assert_eq!(freq.to_string().as_str(), "7/13");
+/// ```
+impl Display for Frequency {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            FrequencyData::TermId(t) => write!(f, "{}", t),
+            FrequencyData::Ratio { n, m } => write!(f, "{n}/{m}"),
+            FrequencyData::Percentage(percentage) => write!(f, "{:.1}%", percentage),
+        }
+    }
+}
+
+/// Convert [`FrequencyData`] to `Frequency` and validate its invariants.
+impl TryFrom<FrequencyData> for Frequency {
+    type Error = FrequencyParseError;
+
+    fn try_from(value: FrequencyData) -> Result<Self, Self::Error> {
+        match value {
+            FrequencyData::TermId(t) => Ok(Self(FrequencyData::TermId(t))),
+            FrequencyData::Ratio { n, m } => Self::from_ratio(n, m),
+            FrequencyData::Percentage(val) => Self::from_percentage(val),
+        }
+    }
+}
+
+impl From<TermId> for Frequency {
+    fn from(value: TermId) -> Self {
+        Self(value.into())
+    }
 }
 
 /// The possible reasons for failing to parse a frequency from a `&str`.
@@ -168,8 +313,8 @@ pub enum FrequencyParseError {
     EmptyVal,
     #[error("`m` is greater than `n`")]
     NGreaterThanM,
-    #[error("Frequency not in range [0, 100]")]
-    FrequencyOutOfBounds,
+    #[error("Percentage not in range [0, 100]")]
+    PercentageOutOfBounds,
     #[error("Unparsable value")]
     UnparsableValue,
 }
@@ -189,7 +334,7 @@ static FREQUENCY_PT: LazyLock<Regex> = LazyLock::new(|| {
 /// The parsing fails if the payload does not correspond to one of the supported input formats:
 /// * ratio - `n`/`m` (e.g. `7/13`) to represent presence of a feature in `n` individuals
 ///   out of `m` tested for feature's presence.
-/// * percentage - e.g. 53.85%. Percent sign `%` is obligatory. The value must be between $[0, 100.0]$.
+/// * percentage - e.g. 53.85%. Percent sign `%` is obligatory. The value must be between \[0, 100\].
 /// * term ID - e.g. `HP:0040284` for [Very rare (HP:0040284)](https://hpo.jax.org/browse/term/HP:0040284).
 ///
 /// # Note
@@ -205,17 +350,17 @@ static FREQUENCY_PT: LazyLock<Regex> = LazyLock::new(|| {
 /// Parse a ratio such as `7/13`:
 ///
 /// ```
-/// use oboannotation::hpo::Frequency;
+/// use oboannotation::hpo::{Frequency, FrequencyData};
 ///
 /// let frequency: Result<Frequency, _> = "7/13".parse();
 /// assert!(frequency.is_ok());
 ///
 /// let frequency = frequency.unwrap();
 ///
-/// assert_eq!(frequency, Frequency::Ratio {n: 7, m: 13});
+/// assert_eq!(frequency.data(), &FrequencyData::Ratio {n: 7, m: 13});
 /// ```
 ///
-/// Fails if $n>m$:
+/// Fails if `n > m`:
 /// ```
 /// use oboannotation::hpo::{Frequency, FrequencyParseError};
 ///
@@ -229,13 +374,13 @@ static FREQUENCY_PT: LazyLock<Regex> = LazyLock::new(|| {
 /// Parse a percentage value, such as `53.85%`.
 ///
 /// ```
-/// use oboannotation::hpo::Frequency;
+/// use oboannotation::hpo::{Frequency, FrequencyData};
 ///
 /// let frequency: Result<Frequency, _> = "53.85%".parse();
 /// assert!(frequency.is_ok());
 ///
 /// let frequency = frequency.unwrap();
-/// assert!(matches!(frequency, Frequency::Percentage(53.85)));
+/// assert_eq!(frequency.data(), &FrequencyData::Percentage(53.85));
 /// ```
 ///
 /// ## Term id
@@ -244,14 +389,14 @@ static FREQUENCY_PT: LazyLock<Regex> = LazyLock::new(|| {
 ///
 /// ```
 /// use ontolius::TermId;
-/// use oboannotation::hpo::Frequency;
+/// use oboannotation::hpo::{Frequency, FrequencyData};
 ///
 /// let frequency: Result<Frequency, _> = "HP:0040284".parse();
 /// assert!(frequency.is_ok());
 ///
 /// let frequency = frequency.unwrap();
 /// let very_rare: TermId = "HP:0040284".parse().unwrap();
-/// assert!(matches!(frequency, Frequency::TermId(very_rare)));
+/// assert_eq!(frequency.data(), &FrequencyData::TermId(very_rare));
 /// ```
 ///
 impl FromStr for Frequency {
@@ -261,29 +406,21 @@ impl FromStr for Frequency {
         if s.is_empty() {
             Err(FrequencyParseError::EmptyVal)
         } else if let Some(cap) = RATIO_PT.captures(s) {
-            let n = cap["numerator"]
+            let n: u32 = cap["numerator"]
                 .parse()
                 .expect("Regexp should ensure that numerator is parsable into a `u32` value");
-            let m = cap["denominator"]
+            let m: u32 = cap["denominator"]
                 .parse()
                 .expect("Regexp should ensure that denominator is parsable into a `u32` value");
-            if n > m {
-                Err(FrequencyParseError::NGreaterThanM)
-            } else {
-                Ok(Self::Ratio { n, m })
-            }
+            Frequency::from_ratio(n, m)
         } else if let Some(cap) = FREQUENCY_PT.captures(s) {
             let frequency: f64 = cap["frequency"]
                 .parse()
                 .expect("Regexp pattern should ensure that frequency is parsable into f64");
-            if (0. ..=100.).contains(&frequency) {
-                Ok(Self::Percentage(frequency))
-            } else {
-                Err(FrequencyParseError::FrequencyOutOfBounds)
-            }
+            Frequency::from_percentage(frequency)
         } else {
             // Fall back to TermId
-            match s.parse().map(Self::TermId) {
+            match s.parse().map(|t| Self(FrequencyData::TermId(t))) {
                 Ok(frequency) => Ok(frequency),
                 Err(_) => Err(FrequencyParseError::UnparsableValue),
             }
@@ -291,31 +428,9 @@ impl FromStr for Frequency {
     }
 }
 
-/// Format a `Frequency`.
-///
-/// # Examples
-///
-/// ```
-/// use ontolius::TermId;
-/// use oboannotation::hpo::Frequency;
-///
-/// let freq: Frequency = Frequency::TermId("HP:0040284".parse().unwrap());
-///
-/// assert_eq!(freq.to_string().as_str(), "HP:0040284");
-/// ```
-impl Display for Frequency {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::TermId(t) => write!(f, "{}", t),
-            Self::Ratio { n, m } => write!(f, "{n}/{m}"),
-            Self::Percentage(percentage) => write!(f, "{:.1}%", percentage),
-        }
-    }
-}
-
 #[cfg(test)]
 mod test_frequency {
-    use crate::hpo::{Frequency, FrequencyParseError};
+    use super::{Frequency, FrequencyData, FrequencyParseError};
 
     #[test]
     fn from_str_empty() {
@@ -334,14 +449,14 @@ mod test_frequency {
     }
 
     #[test]
-    fn from_str_frequency_out_of_bounds() {
+    fn from_str_percentage_out_of_bounds() {
         assert_eq!(
-            "-1.11%".parse::<Frequency>().unwrap_err(),
-            FrequencyParseError::FrequencyOutOfBounds
+            "-0%".parse::<Frequency>().unwrap_err(),
+            FrequencyParseError::PercentageOutOfBounds
         );
         assert_eq!(
             "100.01%".parse::<Frequency>().unwrap_err(),
-            FrequencyParseError::FrequencyOutOfBounds
+            FrequencyParseError::PercentageOutOfBounds
         );
     }
 
@@ -351,6 +466,22 @@ mod test_frequency {
         assert!(f.is_err());
 
         assert_eq!(f.unwrap_err(), FrequencyParseError::UnparsableValue);
+    }
+
+    #[test]
+    fn test_creating_from_negative_zero_percent() {
+        let result = Frequency::from_percentage(-0.);
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            FrequencyParseError::PercentageOutOfBounds
+        );
+    }
+
+    #[test]
+    fn test_we_pay_nothing_for_the_frequency_wrapper() {
+        assert_eq!(size_of::<Frequency>(), size_of::<FrequencyData>());
     }
 }
 
@@ -384,7 +515,7 @@ pub struct HpoAnnotations {
 /// Parse disease-phenotype annotations from HPO annotation file.
 pub mod io {
     use super::{
-        AnnotationReference, Aspect, EvidenceCode, Frequency, FrequencyParseError, HpoAnnotation,
+        AnnotationReference, Aspect, EvidenceCode, FrequencyParseError, HpoAnnotation,
         HpoAnnotations, Sex,
     };
     use crate::io::{AnnotationWriter, ReadAnnotation};
@@ -484,7 +615,7 @@ pub mod io {
                     FrequencyParseError::EmptyVal => {
                         write!(f, "Empty value: {}", self.fields[FREQUENCY_COL_IDX])
                     }
-                    FrequencyParseError::FrequencyOutOfBounds => write!(
+                    FrequencyParseError::PercentageOutOfBounds => write!(
                         f,
                         "Frequency out of bounds: {}",
                         self.fields[FREQUENCY_COL_IDX]
@@ -521,7 +652,7 @@ pub mod io {
         }
     }
 
-    /// The reasons for failure in parsing of HPO annotation line in [`HpoAnnotation::parse_hpoa_line`].
+    /// The reasons for failure in parsing of HPO annotation line in [`HpoAnnotation::read_str`].
     #[derive(Debug, thiserror::Error, PartialEq)]
     pub enum HpoaErrorReason {
         #[error("Cannot parse a record with {0}!={col_cnt}", col_cnt=HPOA_COLUMN_COUNT)]
@@ -735,7 +866,7 @@ pub mod io {
 
             // frequency
             if let Some(frequency) = &self.frequency {
-                format_frequency(w, frequency)?;
+                write!(w, "{frequency}")?
             }
             write!(w, "\t")?;
 
@@ -813,7 +944,7 @@ pub mod io {
                     Ok(frequency) => Some(frequency),
                     Err(e) => match e {
                         FrequencyParseError::EmptyVal => None,
-                        FrequencyParseError::FrequencyOutOfBounds
+                        FrequencyParseError::PercentageOutOfBounds
                         | FrequencyParseError::UnparsableValue
                         | FrequencyParseError::NGreaterThanM => {
                             return Err(HpoaErrorReason::InvalidFrequency(e));
@@ -867,17 +998,17 @@ pub mod io {
         use crate::hpo::io::hpoa_examples::{
             make_complex_hpo_annotation, make_hpo_annotations, make_simple_hpo_annotation,
         };
-        use crate::hpo::{AnnotationReference, Aspect, EvidenceCode, Frequency};
+        use crate::hpo::{AnnotationReference, Aspect, EvidenceCode, FrequencyData};
         use crate::io::{AnnotationLoader, AnnotationWriter, ReadAnnotation, WriteAnnotation};
         use ontolius::TermIdParseError;
         use std::io::BufRead;
 
         #[test]
         fn write_hpo_annotations() -> Result<(), Box<dyn std::error::Error>> {
-            let anns = make_hpo_annotations();
+            let annotations = make_hpo_annotations();
 
             let mut w = Vec::new();
-            anns.store_to_write(&mut w)?;
+            annotations.store_to_write(&mut w)?;
 
             let lines: Vec<_> = w.lines().map(|l| l.unwrap()).collect();
             assert_eq!(
@@ -937,8 +1068,8 @@ pub mod io {
             assert!(hpo_line.onset.is_none());
             assert_eq!(hpo_line.frequency.is_some(), true);
             assert_eq!(
-                &hpo_line.frequency.unwrap(),
-                &Frequency::Ratio { n: 29, m: 199 }
+                hpo_line.frequency.unwrap().data(),
+                &FrequencyData::Ratio { n: 29, m: 199 }
             );
 
             assert!(hpo_line.sex.is_none());
@@ -1015,7 +1146,7 @@ pub mod io {
                     EvidenceCode::PCS,
                 )],
                 onset: Some(("HP", "0003577").into()),
-                frequency: Some(Frequency::Ratio { n: 4, m: 8 }),
+                frequency: Some(Frequency::from_ratio(4u8, 8u8).unwrap()),
                 sex: Some(Sex::Male),
                 modifiers: vec![("HP", "0012828").into()],
                 aspect: Aspect::Phenotype,
@@ -1083,13 +1214,6 @@ pub mod io {
             Sex::Male => write!(w, "MALE"),
             Sex::Female => write!(w, "FEMALE"),
         }
-    }
-
-    fn format_frequency<W>(w: &mut W, frequency: &Frequency) -> std::io::Result<()>
-    where
-        W: Write,
-    {
-        write!(w, "{frequency}")
     }
 
     fn write_annotation_reference_evidence_code<W>(

--- a/src/hpo.rs
+++ b/src/hpo.rs
@@ -1075,7 +1075,8 @@ pub mod io {
         {
             // Comments
             // #description: "HPO annotations for rare diseases [8362: OMIM; 47: DECIPHER; 4283 ORPHA]"
-            let disease_counts = count_diseases(&self.lines);
+            let mut disease_counts = count_diseases(&self.lines);
+            disease_counts.sort();
             write!(
                 &mut write,
                 "#description: \"HPO annotations for rare diseases"

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,7 +1,7 @@
 //! Load ontology annotations.
 use std::fs::File;
 
-use std::io::{self, BufRead, BufReader, Read};
+use std::io::{self, BufRead, BufReader, Read, Write};
 use std::path::Path;
 
 use thiserror::Error;
@@ -64,4 +64,27 @@ pub trait AnnotationLoader<A> {
     fn load_from_buf_read<R>(&self, read: R) -> Result<A, AnnotationLoadError>
     where
         R: BufRead;
+}
+
+pub trait WriteAnnotation<Fmt> {
+    fn write_ann<W>(&self, w: &mut W) -> io::Result<()>
+    where
+        W: Write;
+}
+
+pub trait ReadAnnotation<Fmt> {
+    type Err;
+    fn read<R>(&mut self, read: &mut R) -> Result<(), Self::Err>
+    where
+        R: BufRead;
+
+    fn read_default<R>(read: &mut R) -> Result<Self, Self::Err>
+    where
+        R: BufRead,
+        Self: Default,
+    {
+        let mut val = Self::default();
+        val.read(read)?;
+        Ok(val)
+    }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,9 +1,9 @@
 //! Load ontology annotations.
+
 use std::fs::File;
 
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::path::Path;
-
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -40,28 +40,35 @@ pub enum AnnotationLoadError {
     Error(String),
 }
 
+pub trait AnnotationWriter<Fmt> {
+    type Err;
+    fn store_to_write<W>(self, write: W) -> Result<(), Self::Err>
+    where
+        W: Write;
+}
+
 /// Load annotations from path, [`Read`], or [`BufRead`].
 ///
 /// The loading is performed in a strict validation.
-pub trait AnnotationLoader<A> {
+pub trait AnnotationLoader<Fmt>: Sized {
     /// Load annotation from a file path.
-    fn load_from_path<P>(&self, path: P) -> Result<A, AnnotationLoadError>
+    fn load_from_path<P>(path: P) -> Result<Self, AnnotationLoadError>
     where
         P: AsRef<Path>,
     {
-        self.load_from_read(File::open(path)?)
+        Self::load_from_read(File::open(path)?)
     }
 
     /// Load annotation from a reader.
-    fn load_from_read<R>(&self, read: R) -> Result<A, AnnotationLoadError>
+    fn load_from_read<R>(read: R) -> Result<Self, AnnotationLoadError>
     where
         R: Read,
     {
-        self.load_from_buf_read(BufReader::new(read))
+        Self::load_from_buf_read(BufReader::new(read))
     }
 
     /// Load annotation from a buffered reader.
-    fn load_from_buf_read<R>(&self, read: R) -> Result<A, AnnotationLoadError>
+    fn load_from_buf_read<R>(read: R) -> Result<Self, AnnotationLoadError>
     where
         R: BufRead;
 }
@@ -72,19 +79,8 @@ pub trait WriteAnnotation<Fmt> {
         W: Write;
 }
 
-pub trait ReadAnnotation<Fmt> {
+pub trait ReadAnnotation<Fmt>: Sized {
     type Err;
-    fn read<R>(&mut self, read: &mut R) -> Result<(), Self::Err>
-    where
-        R: BufRead;
 
-    fn read_default<R>(read: &mut R) -> Result<Self, Self::Err>
-    where
-        R: BufRead,
-        Self: Default,
-    {
-        let mut val = Self::default();
-        val.read(read)?;
-        Ok(val)
-    }
+    fn read_str(val: &str) -> Result<Self, Self::Err>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,20 +15,17 @@
 //!
 //! ```rust
 //! use oboannotation::io::AnnotationLoader;
-//! use oboannotation::hpo::HpoAnnotation;
-//! use oboannotation::hpo::io::{HpoAnnotationLines, HpoAnnotationLoader};
+//! use oboannotation::hpo::{HpoAnnotation, HpoAnnotations};
 //!
 //! // 👇 Replace with path to a real file 👇
 //! let fpath_hpoa = "data/phenotype.real-shortlist.hpoa";
-//!
-//! let loader = HpoAnnotationLoader::default();
-//! let data: HpoAnnotationLines = loader.load_from_path(fpath_hpoa)
+//! let data: HpoAnnotations = HpoAnnotations::load_from_path(fpath_hpoa)
 //!                                  .expect("Toy HPOA should be well formatted");
 //!
 //! assert_eq!(data.lines.len(), 86); // Toy HPOA includes 86 records
 //! ```
 //!
-//! See [`HpoAnnotationLines`][`crate::hpo::io::HpoAnnotationLines`] and [`HpoAnnotation`][`crate::hpo::HpoAnnotation`]
+//! See [`HpoAnnotationLines`][`crate::hpo::HpoAnnotationLines`] and [`HpoAnnotation`][`crate::hpo::HpoAnnotation`]
 //! to learn more about the data format.
 //!
 //! ## Load GO annotations
@@ -37,13 +34,12 @@
 //!
 //! ```rust
 //! use oboannotation::io::AnnotationLoader;
-//! use oboannotation::go::{GoAnnotations, GoGafAnnotationLoader};
+//! use oboannotation::go::{GoAnnotations};
 //!
 //! // 👇 Replace with path to a real file 👇
 //! let fpath_goa = "data/goa_human.SURF1_FBN1.gaf";
 //!
-//! let loader = GoGafAnnotationLoader;
-//! let data: GoAnnotations = loader.load_from_path(fpath_goa)
+//! let data: GoAnnotations = GoAnnotations::load_from_path(fpath_goa)
 //!                             .expect("Toy GO annotations should be well formatted");
 //!
 //! assert_eq!(data.annotations.len(), 156); // Toy GO annotations include 156 records

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! let data: HpoAnnotations = HpoAnnotations::load_from_path(fpath_hpoa)
 //!                                  .expect("Toy HPOA should be well formatted");
 //!
-//! assert_eq!(data.lines.len(), 86); // Toy HPOA includes 86 records
+//! assert_eq!(data.annotations().len(), 86); // Toy HPOA includes 86 records
 //! ```
 //!
 //! See [`HpoAnnotations`][`crate::hpo::HpoAnnotations`] and [`HpoAnnotation`][`crate::hpo::HpoAnnotation`]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,9 @@
 //! to learn more about the data format.
 //!
 //! ## Load GO annotations
-//! 
+//!
 //! Load a toy GO annotation file containing annotations of *FBN1* and *SURF1* genes for *Homo sapiens*.
-//! 
+//!
 //! ```rust
 //! use oboannotation::io::AnnotationLoader;
 //! use oboannotation::go::{GoAnnotations, GoGafAnnotationLoader};
@@ -50,7 +50,8 @@
 //! ```
 //! See [`GoAnnotations`][`crate::go::GoAnnotations`] and [`GoAnnotation`][`crate::go::GoAnnotation`]
 //! to learn more about the data format.
-//! 
+//!
+pub mod format;
 pub mod go;
 pub mod hpo;
 pub mod io;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! assert_eq!(data.lines.len(), 86); // Toy HPOA includes 86 records
 //! ```
 //!
-//! See [`HpoAnnotationLines`][`crate::hpo::HpoAnnotationLines`] and [`HpoAnnotation`][`crate::hpo::HpoAnnotation`]
+//! See [`HpoAnnotations`][`crate::hpo::HpoAnnotations`] and [`HpoAnnotation`][`crate::hpo::HpoAnnotation`]
 //! to learn more about the data format.
 //!
 //! ## Load GO annotations

--- a/tests/test_hpoa.rs
+++ b/tests/test_hpoa.rs
@@ -2,12 +2,9 @@ const _FPATH_SMALL_HPO: &str = "data/hp.small.json";
 const FPATH_SMALL_HPOA: &str = "data/phenotype.real-shortlist.hpoa";
 
 mod hpo_annotation_parser {
-    use oboannotation::{
-        hpo::{Frequency, HpoAnnotations},
-        io::AnnotationLoader,
-    };
-
     use super::FPATH_SMALL_HPOA;
+    use oboannotation::hpo::FrequencyData;
+    use oboannotation::{hpo::HpoAnnotations, io::AnnotationLoader};
 
     #[test]
     fn load_from_path() {
@@ -26,12 +23,8 @@ mod hpo_annotation_parser {
         assert_eq!(first.disease_id.to_string().as_str(), "OMIM:154700");
         assert_eq!(first.disease_name.as_str(), "Marfan syndrome");
         assert_eq!(first.annotation_references.len(), 2);
-        assert_eq!(
-            first.frequency.as_ref().expect("Should be present"),
-            &Frequency::Ratio {
-                n: 29,
-                m: 199
-            }
-        )
+
+        let frequency_data = first.frequency.as_ref().unwrap().data();
+        assert_eq!(frequency_data, &FrequencyData::Ratio { n: 29, m: 199 })
     }
 }

--- a/tests/test_hpoa.rs
+++ b/tests/test_hpoa.rs
@@ -12,12 +12,12 @@ mod hpo_annotation_parser {
         let data = HpoAnnotations::load_from_path(FPATH_SMALL_HPOA)
             .expect("Sample data should be well formatted");
 
-        assert_eq!(data.version.as_str(), "2023-04-05");
-        assert_eq!(data.hpo_version.as_str(), "2023-04-05");
-        assert_eq!(data.lines.len(), 86);
+        assert_eq!(data.version(), "2023-04-05");
+        assert_eq!(data.hpo_version(), "2023-04-05");
+        assert_eq!(data.annotations().len(), 86);
 
         let first = data
-            .lines
+            .annotations()
             .first()
             .expect("We should have more than one line");
 

--- a/tests/test_hpoa.rs
+++ b/tests/test_hpoa.rs
@@ -28,3 +28,47 @@ mod hpo_annotation_parser {
         assert_eq!(frequency_data, &FrequencyData::Ratio { n: 29, m: 199 })
     }
 }
+
+mod create_annotations {
+    use oboannotation::hpo::{
+        AnnotationReference, Aspect, EvidenceCode, Frequency, FrequencyData, HpoAnnotation,
+    };
+
+    #[test]
+    fn create_hpoa_entries() {
+        // OMIM:154700 Marfan syndrome HP:0001377 PMID:28050285;PMID:33436942 PCS 29/199 P HPO:probinson[2021-05-27];HPO:probinson[2021-04-01]
+        let ann = HpoAnnotation::builder()
+            .disease(("OMIM", "154700"), "Marfan syndrome")
+            .phenotype(("HP", "0001377")) // Limited elbow extension
+            .extend_annotation_references([
+                AnnotationReference::new(("PMID", "33436942").into(), EvidenceCode::PCS),
+                AnnotationReference::new(("PMID", "28050285").into(), EvidenceCode::PCS),
+            ])
+            .frequency("29/199".parse::<Frequency>().unwrap())
+            .aspect_phenotype()
+            .extend_curators(["HPO:probinson[2021-05-27]", "HPO:probinson[2021-04-01]"])
+            .build();
+
+        assert_eq!(ann.disease_id, ("OMIM", "154700"));
+        assert_eq!(ann.disease_name, "Marfan syndrome");
+        assert_eq!(ann.is_negated, false);
+        assert_eq!(ann.phenotype_term_id, ("HP", "0001377"));
+        assert_eq!(ann.annotation_references.len(), 2);
+        assert_eq!(
+            ann.annotation_references.first().unwrap(),
+            &AnnotationReference::new(("PMID", "28050285").into(), EvidenceCode::PCS,)
+        );
+        assert!(ann.onset.is_none());
+        assert_eq!(
+            ann.frequency.unwrap().data(),
+            &FrequencyData::Ratio { n: 29, m: 199 }
+        );
+        assert!(ann.sex.is_none());
+        assert!(ann.modifiers.is_empty());
+        assert_eq!(ann.aspect, Aspect::Phenotype);
+        assert_eq!(
+            &ann.curators,
+            &["HPO:probinson[2021-04-01]", "HPO:probinson[2021-05-27]",]
+        );
+    }
+}

--- a/tests/test_hpoa.rs
+++ b/tests/test_hpoa.rs
@@ -2,9 +2,8 @@ const _FPATH_SMALL_HPO: &str = "data/hp.small.json";
 const FPATH_SMALL_HPOA: &str = "data/phenotype.real-shortlist.hpoa";
 
 mod hpo_annotation_parser {
-
     use oboannotation::{
-        hpo::{Frequency, io::HpoAnnotationLoader},
+        hpo::{Frequency, HpoAnnotations},
         io::AnnotationLoader,
     };
 
@@ -12,13 +11,11 @@ mod hpo_annotation_parser {
 
     #[test]
     fn load_from_path() {
-        let parser = HpoAnnotationLoader::default();
-
-        let data = parser
-            .load_from_path(FPATH_SMALL_HPOA)
+        let data = HpoAnnotations::load_from_path(FPATH_SMALL_HPOA)
             .expect("Sample data should be well formatted");
 
         assert_eq!(data.version.as_str(), "2023-04-05");
+        assert_eq!(data.hpo_version.as_str(), "2023-04-05");
         assert_eq!(data.lines.len(), 86);
 
         let first = data
@@ -32,8 +29,8 @@ mod hpo_annotation_parser {
         assert_eq!(
             first.frequency.as_ref().expect("Should be present"),
             &Frequency::Ratio {
-                numerator: 29,
-                denominator: 199
+                n: 29,
+                m: 199
             }
         )
     }

--- a/tests/test_hpoa.rs
+++ b/tests/test_hpoa.rs
@@ -4,6 +4,7 @@ const FPATH_SMALL_HPOA: &str = "data/phenotype.real-shortlist.hpoa";
 mod hpo_annotation_parser {
     use super::FPATH_SMALL_HPOA;
     use oboannotation::hpo::FrequencyData;
+    use oboannotation::io::AnnotationWriter;
     use oboannotation::{hpo::HpoAnnotations, io::AnnotationLoader};
 
     #[test]
@@ -26,6 +27,47 @@ mod hpo_annotation_parser {
 
         let frequency_data = first.frequency.as_ref().unwrap().data();
         assert_eq!(frequency_data, &FrequencyData::Ratio { n: 29, m: 199 })
+    }
+
+    #[test]
+    fn write_hpoa_annotations() {
+        // Let's assume we obtain the annotations from somewhere.
+        let anns = HpoAnnotations::load_from_path(FPATH_SMALL_HPOA)
+            .expect("Sample data should be well formatted");
+
+        // We can write them in the HPOA format into a file ...
+        // let mut write = File::create("phenotype.new.hpoa").expect("We are allowed to write");
+        // ... or into a buffer (this case).
+        let mut write = vec![];
+        anns.store_to_write(&mut write)
+            .expect("Writing into a Vec should not fail");
+
+        let hpoa_lines: Vec<_> = std::str::from_utf8(&write)
+            .expect("HPOA should be a utf8 string")
+            .lines()
+            .collect();
+
+        // The first 5 HPOA lines should look roughly like this ...
+        assert_eq!(
+            &hpoa_lines[..5],
+            &[
+                "#description: \"HPO annotations for rare diseases [2: OMIM]\"",
+                "#version: 2023-04-05",
+                "#tracker: https://github.com/obophenotype/human-phenotype-ontology/issues",
+                "#hpo-version: https://purl.obolibrary.org/obo/hp/releases/2023-04-05/hp.json",
+                "database_id\tdisease_name\tqualifier\thpo_id\treference\tevidence\tonset\tfrequency\tsex\tmodifier\taspect\tbiocuration"
+            ]
+        );
+
+        // ... while the records look like:
+        assert_eq!(
+            &hpoa_lines[5..8],
+            &[
+                "OMIM:154700\tMarfan syndrome\t\tHP:0001377\tPMID:28050285;PMID:33436942\tPCS\t\t29/199\t\t\tP\tHPO:probinson[2021-05-27];HPO:probinson[2021-04-01]",
+                "OMIM:154700\tMarfan syndrome\t\tHP:0000486\tPMID:8172269\tPCS\t\t110/573\t\t\tP\tHPO:skoehler[2015-07-26];HPO:probinson[2020-08-03]",
+                "OMIM:154700\tMarfan syndrome\t\tHP:0005136\tOMIM:154700\tIEA\t\t\t\t\tP\tHPO:probinson[2012-04-24]"
+            ]
+        );
     }
 }
 


### PR DESCRIPTION
Add support for writing HPO annotations in the HPOA format.

See `tests/test_hpoa.rs#write_hpoa_annotations()` for a use case.